### PR TITLE
Fix pack.mcmeta format

### DIFF
--- a/src/main/resources/fileTemplates/j2ee/forge/pack.mcmeta.ft
+++ b/src/main/resources/fileTemplates/j2ee/forge/pack.mcmeta.ft
@@ -1,9 +1,11 @@
 {
     "pack": {
         "description": "${ARTIFACT_ID} resources",
-        "pack_format": ${PACK_FORMAT},
         #if (${PACK_COMMENT} != "")
+        "pack_format": ${PACK_FORMAT},
         "_comment": "${PACK_COMMENT}"
+        #else
+        "pack_format": ${PACK_FORMAT}
         #end
     }
 }


### PR DESCRIPTION
When we don't have any comments in this file, a useless comma create an error on mod testing